### PR TITLE
make use of new BO flags in zocl.

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -1,6 +1,6 @@
 ROOT	:= $(dir $(M))
 
-ccflags-y := -Iinclude/drm -I${ROOT}/../../include
+ccflags-y := -Iinclude/drm -I${ROOT}/../../include -I${ROOT}/../../common/drv
 zocl-y := \
 	sched_exec.o \
 	zocl_sysfs.o \

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.h
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.h
@@ -1,0 +1,78 @@
+/*
+ * A GEM style (optionally CMA backed) device manager for ZynQ based
+ * OpenCL accelerators.
+ *
+ * Copyright (C) 2019 Xilinx, Inc. All rights reserved.
+ *
+ * Authors:
+ *    Larry Liu    <yliu@xilinx.com>
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef _ZOCL_BO_H
+#define _ZOCL_BO_H
+
+#include "xclhal2_mem.h"
+
+/**
+ * XCL BO Flags bits layout
+ *
+ * bits  0 ~ 15: DDR BANK index
+ * bits 16 ~ 31: BO flags
+ *
+ * TODO These flags are copied from old xclhal2_mem.h. BO flags
+ * in current xclhal2_mem.h are modified. To prevent zocl from
+ * being broken, we keep a copy of old flags and implement a
+ * converter from the new flags to these old ones. These flags
+ * will be removed when we implement BO BO BO project at edge
+ * side.
+ */
+#define ZOCL_BO_FLAGS_CACHEABLE		(1 << 24)
+#define ZOCL_BO_FLAGS_HOST_BO		(1 << 25)
+#define ZOCL_BO_FLAGS_COHERENT		(1 << 26)
+#define ZOCL_BO_FLAGS_SVM		(1 << 27)
+#define ZOCL_BO_FLAGS_USERPTR		(1 << 28)
+#define ZOCL_BO_FLAGS_CMA		(1 << 29)
+#define ZOCL_BO_FLAGS_P2P		(1 << 30)
+#define ZOCL_BO_FLAGS_EXECBUF		(1 << 31)
+
+/* BO types we support */
+#define ZOCL_BO_NORMAL	(XRT_DRV_BO_HOST_MEM | XRT_DRM_SHMEM | \
+			XRT_DRV_BO_DRM_ALLOC)
+#define ZOCL_BO_EXECBUF	(ZOCL_BO_NORMAL)
+#define ZOCL_BO_CACHE	(ZOCL_BO_NORMAL | XRT_CACHEABLE)
+#define ZOCL_BO_USERPTR	(XRT_USER_MEM | XRT_DRV_BO_USER_ALLOC)
+#define ZOCL_BO_SVM	(XRT_DRV_BO_HOST_MEM | XRT_DRM_SHMEM | \
+			XRT_DRV_BO_DRM_ALLOC)
+#define ZOCL_BO_PL_DDR	(XRT_DEVICE_MEM)
+#define ZOCL_BO_HOST_BO	(XRT_DRV_BO_HOST_MEM)
+#define ZOCL_BO_IMPORT	(XRT_DRM_IMPORT | XRT_DRV_BO_HOST_MEM)
+
+static inline uint32_t zocl_convert_bo_uflags(uint32_t uflags)
+{
+	uint32_t zflags = 0;
+
+	/*
+	 * Keep the bank index and remove all flags, except EXECBUF and
+	 * CACHEABLE.
+	 */
+	if (uflags & XCL_BO_FLAGS_EXECBUF)
+		zflags |= ZOCL_BO_FLAGS_EXECBUF;
+
+	if (uflags & XCL_BO_FLAGS_CACHEABLE)
+		zflags |= ZOCL_BO_FLAGS_CACHEABLE;
+
+	zflags |= (uflags & 0xFFFF);
+
+	return zflags;
+}
+
+#endif /* _ZOCL_BO_H */

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.h
@@ -29,7 +29,7 @@
 #include "zocl_ioctl.h"
 #include "zocl_ert.h"
 #include "zocl_util.h"
-#include "xclhal2_mem.h"
+#include "zocl_bo.h"
 
 /* Ensure compatibility with newer kernels and backported Red Hat kernels. */
 /* The y2k38 bug fix was introduced with Kernel 3.17 and backported to Red Hat
@@ -129,13 +129,13 @@ drm_zocl_bo *to_zocl_bo(struct drm_gem_object *bo)
 	static inline bool
 zocl_bo_userptr(const struct drm_zocl_bo *bo)
 {
-	return (bo->flags & XCL_BO_FLAGS_USERPTR);
+	return (bo->flags & ZOCL_BO_FLAGS_USERPTR);
 }
 
 	static inline bool
 zocl_bo_execbuf(const struct drm_zocl_bo *bo)
 {
-	return (bo->flags & XCL_BO_FLAGS_EXECBUF);
+	return (bo->flags & ZOCL_BO_FLAGS_EXECBUF);
 }
 
 


### PR DESCRIPTION
A temporary fix to zocl after xclhal2_mem.h remove some flags zocl is using. We just make a copy of that flags and change the pre-fix from XCL to ZOCL. We will revisit these flags and move to BO types later